### PR TITLE
Updated flipflops

### DIFF
--- a/blocks/Logic/Sequential/Flip-flop D.ice
+++ b/blocks/Logic/Sequential/Flip-flop D.ice
@@ -71,11 +71,22 @@
           }
         },
         {
+          "id": "7c0dcfe6-efa3-47d5-bc41-b52e1a3daf47",
+          "type": "basic.constant",
+          "data": {
+            "name": "INI",
+            "value": "0",
+            "local": false
+          },
+          "position": {
+            "x": 568,
+            "y": 16
+          }
+        },
+        {
           "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
           "type": "basic.code",
           "data": {
-            "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-            "params": [],
             "ports": {
               "in": [
                 {
@@ -89,8 +100,16 @@
                 {
                   "name": "q"
                 }
-              ]
-            }
+              ],
+              "inoutLeft": [],
+              "inoutRight": []
+            },
+            "params": [
+              {
+                "name": "INI"
+              }
+            ],
+            "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n\n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n\n"
           },
           "position": {
             "x": 432,
@@ -131,6 +150,16 @@
           "target": {
             "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
             "port": "in"
+          }
+        },
+        {
+          "source": {
+            "block": "7c0dcfe6-efa3-47d5-bc41-b52e1a3daf47",
+            "port": "constant-out"
+          },
+          "target": {
+            "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+            "port": "INI"
           }
         }
       ]

--- a/blocks/Logic/Sequential/Flip-flop T.ice
+++ b/blocks/Logic/Sequential/Flip-flop T.ice
@@ -138,37 +138,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -202,6 +171,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "d5c0c304-357a-4f03-9765-d50f9f7d53a9",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -233,6 +252,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "d5c0c304-357a-4f03-9765-d50f9f7d53a9",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/2. Flip-flops/01. DFF manual load.ice
+++ b/examples/2. Flip-flops/01. DFF manual load.ice
@@ -138,37 +138,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -202,6 +171,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "5c23f968-b0f2-4f1a-bad0-397e50c34c0c",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n\n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -233,6 +252,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "5c23f968-b0f2-4f1a-bad0-397e50c34c0c",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/2. Flip-flops/02. Chain of three DFFs.ice
+++ b/examples/2. Flip-flops/02. Chain of three DFFs.ice
@@ -407,37 +407,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -471,6 +440,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "0914d43b-6de9-4105-a841-99bdaa35e718",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -502,6 +521,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "0914d43b-6de9-4105-a841-99bdaa35e718",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/2. Flip-flops/03. Ring of four DFFs.ice
+++ b/examples/2. Flip-flops/03. Ring of four DFFs.ice
@@ -563,37 +563,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -627,6 +596,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "1513551f-b6a4-44cd-903d-22a51d0e76ea",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -658,6 +677,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "1513551f-b6a4-44cd-903d-22a51d0e76ea",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/2. Flip-flops/04. Toggle button.ice
+++ b/examples/2. Flip-flops/04. Toggle button.ice
@@ -361,37 +361,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -425,6 +394,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "53290528-a8e7-421f-8adc-17ffeaead7b5",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -456,6 +475,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "53290528-a8e7-421f-8adc-17ffeaead7b5",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/2. Flip-flops/05. Binary counter with three TFFs.ice
+++ b/examples/2. Flip-flops/05. Binary counter with three TFFs.ice
@@ -598,37 +598,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -662,6 +631,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "1e44788b-2b60-4039-9737-8bc392a38d53",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -693,6 +712,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "1e44788b-2b60-4039-9737-8bc392a38d53",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/3. Gates/08. Multiplexer 2:1.ice
+++ b/examples/3. Gates/08. Multiplexer 2:1.ice
@@ -558,37 +558,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -622,6 +591,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "41dcdd73-ca1f-41eb-9acd-c65de812dae5",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -653,6 +672,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "41dcdd73-ca1f-41eb-9acd-c65de812dae5",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/4. Muxes/01. Blinking fixed LED.ice
+++ b/examples/4. Muxes/01. Blinking fixed LED.ice
@@ -838,37 +838,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -902,6 +871,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "687bd6e4-7a45-4338-b54e-9e48442b9e6c",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -933,6 +952,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "687bd6e4-7a45-4338-b54e-9e48442b9e6c",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/4. Muxes/02. LED three states.ice
+++ b/examples/4. Muxes/02. LED three states.ice
@@ -1021,37 +1021,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -1085,6 +1054,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "2f48b466-6dfb-4346-a302-82494a9d74d7",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -1116,6 +1135,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "2f48b466-6dfb-4346-a302-82494a9d74d7",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/4. Muxes/03. Multiplexer 4:1.ice
+++ b/examples/4. Muxes/03. Multiplexer 4:1.ice
@@ -1109,37 +1109,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -1173,6 +1142,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "43aa1f4a-5c75-4482-9001-c121f79e7cd2",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -1204,6 +1223,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "43aa1f4a-5c75-4482-9001-c121f79e7cd2",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]

--- a/examples/4. Muxes/04. Shift register.ice
+++ b/examples/4. Muxes/04. Shift register.ice
@@ -1054,37 +1054,6 @@
         "graph": {
           "blocks": [
             {
-              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
-              "type": "basic.code",
-              "data": {
-                "code": "// D flip-flop\n\nreg q = 1'b0;\n\nalways @(posedge clk)\nbegin\n  q <= d;\nend\n\n",
-                "params": [],
-                "ports": {
-                  "in": [
-                    {
-                      "name": "clk"
-                    },
-                    {
-                      "name": "d"
-                    }
-                  ],
-                  "out": [
-                    {
-                      "name": "q"
-                    }
-                  ]
-                }
-              },
-              "position": {
-                "x": 432,
-                "y": 128
-              },
-              "size": {
-                "width": 368,
-                "height": 272
-              }
-            },
-            {
               "id": "6855f64f-fa1c-4371-b2e1-a98970674a96",
               "type": "basic.input",
               "data": {
@@ -1118,6 +1087,56 @@
                 "x": 232,
                 "y": 304
               }
+            },
+            {
+              "id": "0dc00c36-9324-41aa-b07c-5fa6920c5184",
+              "type": "basic.constant",
+              "data": {
+                "name": "",
+                "value": "0",
+                "local": false
+              },
+              "position": {
+                "x": 568,
+                "y": 32
+              }
+            },
+            {
+              "id": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+              "type": "basic.code",
+              "data": {
+                "ports": {
+                  "in": [
+                    {
+                      "name": "clk"
+                    },
+                    {
+                      "name": "d"
+                    }
+                  ],
+                  "out": [
+                    {
+                      "name": "q"
+                    }
+                  ],
+                  "inoutLeft": [],
+                  "inoutRight": []
+                },
+                "params": [
+                  {
+                    "name": "INI"
+                  }
+                ],
+                "code": "// D flip-flop\n\n//-- Initial value\nreg qi = INI;\n\n//-- On the rising edge of the  \n//-- system clock put input\n//-- data in register qi\nalways @(posedge clk)\n  qi <= d;\n \n//-- The output pin q reflects\n//-- the state of register qi\nassign q = qi;\n\n"
+              },
+              "position": {
+                "x": 432,
+                "y": 128
+              },
+              "size": {
+                "width": 368,
+                "height": 272
+              }
             }
           ],
           "wires": [
@@ -1149,6 +1168,16 @@
               "target": {
                 "block": "ffdd9aa2-aea3-4aa9-8431-80e799226774",
                 "port": "in"
+              }
+            },
+            {
+              "source": {
+                "block": "0dc00c36-9324-41aa-b07c-5fa6920c5184",
+                "port": "constant-out"
+              },
+              "target": {
+                "block": "e5222a6e-4717-4f08-99d7-7cde897060ca",
+                "port": "INI"
               }
             }
           ]


### PR DESCRIPTION
Updated flipflops so they would verify and build with
the current toolchain.

	modified:   blocks/Logic/Sequential/Flip-flop D.ice
	modified:   blocks/Logic/Sequential/Flip-flop T.ice
	modified:   examples/2. Flip-flops/01. DFF manual load.ice
	modified:   examples/2. Flip-flops/02. Chain of three DFFs.ice
	modified:   examples/2. Flip-flops/03. Ring of four DFFs.ice
	modified:   examples/2. Flip-flops/04. Toggle button.ice
	modified:   examples/2. Flip-flops/05. Binary counter with three TFFs.ice
	modified:   examples/3. Gates/08. Multiplexer 2:1.ice
	modified:   examples/4. Muxes/01. Blinking fixed LED.ice
	modified:   examples/4. Muxes/02. LED three states.ice
	modified:   examples/4. Muxes/03. Multiplexer 4:1.ice
	modified:   examples/4. Muxes/04. Shift register.ice

 Changes not staged for commit:
	modified:   .gitignore